### PR TITLE
Fix wrong indentation for context

### DIFF
--- a/jekyll/_cci2/workflows.md
+++ b/jekyll/_cci2/workflows.md
@@ -172,11 +172,11 @@ workflows:
       - test1:
           requires:
             - build
-    context: org-global  
+          context: org-global  
       - test2:
           requires:
             - test1
-    context: org-global  
+          context: org-global  
       - deploy:
           requires:
             - test2


### PR DESCRIPTION
Was previously fixed (9160399b) due to misplaced tabs, but accidently not replaced with the right amount of spaces.